### PR TITLE
Add wav2vec phoneme recognizer script with streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to stop streaming.
 - Ensure your microphone or input audio is sampled at 16kHz for the best
   results. The script resamples automatically but original 16kHz recordings
   minimise artifacts.
+
+## Debug
+- This was required:
+export PHONEMIZER_ESPEAK_LIBRARY=$(brew --prefix espeak-ng)/lib/libespeak-ng.dylib

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
 # live-phonemes
-Real-time phoneme detection
+
+Real-time and offline phoneme recognition utilities powered by
+[`facebook/wav2vec2-lv-60-espeak-cv-ft`](https://huggingface.co/facebook/wav2vec2-lv-60-espeak-cv-ft).
+
+## Requirements
+
+- Python 3.9+
+- [PyTorch](https://pytorch.org/) with CPU, CUDA, or MPS support (for Apple Silicon).
+- Python packages: `transformers`, `datasets`, `soundfile`, `sounddevice`, `numpy`.
+
+You can install the Python dependencies with:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install torch torchvision torchaudio
+pip install transformers datasets soundfile sounddevice numpy
+```
+
+Alternatively, install everything via the bundled requirements file:
+
+```bash
+pip install -r requirements.txt
+```
+
+> ℹ️  On Apple Silicon you can install the Metal backend with
+> `pip install "torch>=2.0" --index-url https://download.pytorch.org/whl/cpu`.
+
+The script automatically downloads the pretrained model on first use and caches
+it locally using the Hugging Face transformers cache.
+
+## Usage
+
+All functionality lives in `phoneme_recognizer.py`. The script exposes three
+modes that load the model once and re-use it for inference to minimise latency.
+
+### Run the demo transcription
+
+Downloads a tiny Librispeech example (from the official model docs) and
+transcribes it:
+
+```bash
+python phoneme_recognizer.py demo
+```
+
+### Transcribe an audio file
+
+Pass the path to an audio file. The audio is converted to mono, resampled to
+16kHz if necessary, and the phoneme string is printed to stdout.
+
+```bash
+python phoneme_recognizer.py file --path /path/to/audio.wav
+```
+
+### Real-time transcription from the microphone
+
+Starts a microphone stream sampled at 16kHz, ignoring silence by default. Each
+chunk of detected speech is decoded immediately and the phoneme sequence is
+printed to stdout.
+
+```bash
+python phoneme_recognizer.py stream
+```
+
+Optional tuning parameters:
+
+- `--chunk-seconds`: length of microphone chunks (seconds, default `0.75`).
+- `--silence-threshold`: RMS energy threshold to decide whether a chunk is
+  silent (default `8e-4`).
+- `--device`: explicitly set the torch device (`cpu`, `cuda`, `mps`, ...). By
+  default, the script picks CUDA, then MPS, otherwise CPU.
+
+Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to stop streaming.
+
+## Notes
+
+- The model outputs phoneme strings (no word decoding) as described in the
+  original research. You can post-process the phoneme output using your own
+  pronunciation dictionary if desired.
+- Ensure your microphone or input audio is sampled at 16kHz for the best
+  results. The script resamples automatically but original 16kHz recordings
+  minimise artifacts.

--- a/audio_preprocess.py
+++ b/audio_preprocess.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Convert stereo WAV → mono WAV at 16 kHz
+- Input:  stereo .wav file
+- Output: mono .wav file (16kHz, same dtype as input)
+"""
+
+import sys
+import numpy as np
+from scipy.io import wavfile
+from scipy.signal import resample_poly
+
+def stereo_to_mono_16k(input_path: str, output_path: str):
+    # Load audio
+    sr, data = wavfile.read(input_path)  # sr = sample rate, data = np.array
+
+    if data.ndim == 1:
+        print("Input is already mono.")
+        mono = data.astype(np.float32)
+    elif data.ndim == 2 and data.shape[1] == 2:
+        # Average left and right channels
+        mono = data.mean(axis=1).astype(np.float32)
+    else:
+        raise ValueError("Unsupported audio shape: {}".format(data.shape))
+
+    # Target sample rate
+    target_sr = 16000
+    if sr != target_sr:
+        # Use rational resampling to preserve quality
+        gcd = np.gcd(sr, target_sr)
+        up = target_sr // gcd
+        down = sr // gcd
+        mono = resample_poly(mono, up, down)
+
+    # Normalize back to original dtype range
+    if np.issubdtype(data.dtype, np.integer):
+        max_val = np.iinfo(data.dtype).max
+        min_val = np.iinfo(data.dtype).min
+        mono = np.clip(mono, min_val, max_val).astype(data.dtype)
+    else:
+        mono = mono.astype(np.float32)
+
+    # Save output
+    wavfile.write(output_path, target_sr, mono)
+    print(f"✅ Saved mono 16kHz wav to {output_path}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python stereo_to_mono_16k.py input.wav output.wav")
+        sys.exit(1)
+
+    stereo_to_mono_16k(sys.argv[1], sys.argv[2])

--- a/phoneme_recognizer.py
+++ b/phoneme_recognizer.py
@@ -1,0 +1,279 @@
+"""Phoneme recognition utilities powered by Wav2Vec2.
+
+This script provides two modes of operation:
+1. Offline transcription for a given audio file.
+2. Real-time transcription from the microphone.
+
+It downloads the facebook/wav2vec2-lv-60-espeak-cv-ft model on first use
+and caches it locally via Hugging Face transformers.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import queue
+import sys
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import numpy as np
+import torch
+
+try:
+    import soundfile as sf
+except ImportError as exc:  # pragma: no cover - dependency not installed
+    raise SystemExit(
+        "soundfile is required. Install it with `pip install soundfile`."
+    ) from exc
+
+MODEL_NAME = "facebook/wav2vec2-lv-60-espeak-cv-ft"
+TARGET_SAMPLE_RATE = 16_000
+DEFAULT_MIC_CHUNK_SECONDS = 0.75
+DEFAULT_SILENCE_THRESHOLD = 8e-4
+
+
+def pick_device(preferred: Optional[str] = None) -> torch.device:
+    """Return the most appropriate torch device for inference."""
+    if preferred:
+        device = torch.device(preferred)
+        if device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested but is not available on this system.")
+        if device.type == "mps" and not torch.backends.mps.is_available():
+            raise RuntimeError("MPS was requested but is not available on this system.")
+        return device
+
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():  # macOS Metal backend
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+@dataclass
+class PhonemeRecognizer:
+    """Wraps a wav2vec2 model and processor for phoneme inference."""
+
+    device: torch.device
+    model_name: str = MODEL_NAME
+
+    def __post_init__(self) -> None:
+        from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
+
+        self.processor = Wav2Vec2Processor.from_pretrained(self.model_name)
+        self.model = Wav2Vec2ForCTC.from_pretrained(self.model_name)
+        self.model.to(self.device)
+        self.model.eval()
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _ensure_mono(self, audio: np.ndarray) -> np.ndarray:
+        if audio.ndim == 1:
+            return audio
+        if audio.ndim == 2:
+            return np.mean(audio, axis=1)
+        raise ValueError("Audio must be 1-D or 2-D array")
+
+    def _resample(self, audio: np.ndarray, orig_sr: int) -> np.ndarray:
+        if orig_sr == TARGET_SAMPLE_RATE:
+            return audio
+        if orig_sr <= 0:
+            raise ValueError("Invalid sampling rate")
+        duration = audio.shape[0] / float(orig_sr)
+        target_length = int(round(duration * TARGET_SAMPLE_RATE))
+        if target_length <= 0:
+            raise ValueError("Audio is too short after resampling")
+        # Linear interpolation resampling
+        source_times = np.linspace(0.0, duration, num=audio.shape[0], endpoint=False)
+        target_times = np.linspace(0.0, duration, num=target_length, endpoint=False)
+        return np.interp(target_times, source_times, audio).astype(np.float32)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def transcribe_array(self, audio: np.ndarray, sample_rate: int) -> str:
+        """Transcribe the provided audio array into phoneme sequence."""
+        audio = self._ensure_mono(audio)
+        if not np.isfinite(audio).all():
+            raise ValueError("Audio contains NaNs or infinite values")
+        if audio.dtype != np.float32:
+            audio = audio.astype(np.float32)
+        if sample_rate != TARGET_SAMPLE_RATE:
+            audio = self._resample(audio, sample_rate)
+        inputs = self.processor(
+            audio,
+            sampling_rate=TARGET_SAMPLE_RATE,
+            return_tensors="pt",
+            padding=True,
+        )
+        input_values = inputs.input_values.to(self.device)
+        attention_mask = None
+        if inputs.get("attention_mask") is not None:
+            attention_mask = inputs.attention_mask.to(self.device)
+
+        with torch.no_grad():
+            logits = self.model(input_values, attention_mask=attention_mask).logits
+        predicted_ids = torch.argmax(logits, dim=-1)
+        transcription = self.processor.batch_decode(predicted_ids)
+        return transcription[0]
+
+    def transcribe_file(self, path: str) -> str:
+        """Load a file from disk and transcribe it."""
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        audio, sample_rate = sf.read(path, dtype="float32")
+        return self.transcribe_array(audio, sample_rate)
+
+    # ------------------------------------------------------------------
+    # Demo helper
+    # ------------------------------------------------------------------
+    def run_demo(self) -> str:
+        """Run the demo provided by Hugging Face for quick verification."""
+        from datasets import load_dataset
+
+        dataset = load_dataset(
+            "patrickvonplaten/librispeech_asr_dummy", "clean", split="validation"
+        )
+        audio = np.asarray(dataset[0]["audio"]["array"], dtype=np.float32)
+        return self.transcribe_array(audio, TARGET_SAMPLE_RATE)
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+    def stream_microphone(
+        self,
+        chunk_seconds: float = DEFAULT_MIC_CHUNK_SECONDS,
+        silence_threshold: float = DEFAULT_SILENCE_THRESHOLD,
+    ) -> None:
+        """Stream audio from the default microphone and print phonemes."""
+        try:
+            import sounddevice as sd
+        except ImportError as exc:  # pragma: no cover - dependency not installed
+            raise SystemExit(
+                "sounddevice is required for streaming. Install it with `pip install sounddevice`."
+            ) from exc
+
+        chunk_frames = max(1, int(TARGET_SAMPLE_RATE * chunk_seconds))
+        audio_queue: "queue.Queue[np.ndarray]" = queue.Queue()
+
+        def callback(indata, frames, _time, status):
+            if status:
+                print(status, file=sys.stderr)
+            audio_queue.put(indata.copy())
+
+        print(
+            "Starting microphone stream. Press Ctrl+C to stop.",
+            file=sys.stderr,
+        )
+        with sd.InputStream(
+            samplerate=TARGET_SAMPLE_RATE,
+            channels=1,
+            blocksize=chunk_frames,
+            dtype="float32",
+            callback=callback,
+        ):
+            try:
+                while True:
+                    chunk = audio_queue.get()
+                    if chunk.size == 0:
+                        continue
+                    chunk = chunk[:, 0]
+                    rms = math.sqrt(float(np.mean(chunk ** 2)))
+                    if rms < silence_threshold:
+                        continue
+                    transcription = self.transcribe_array(chunk, TARGET_SAMPLE_RATE)
+                    cleaned = transcription.strip()
+                    if cleaned:
+                        print(cleaned, flush=True)
+            except KeyboardInterrupt:
+                print("\nMicrophone streaming stopped.", file=sys.stderr)
+
+
+# ----------------------------------------------------------------------
+# Command-line interface
+# ----------------------------------------------------------------------
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "mode",
+        choices=("file", "stream", "demo"),
+        help="Whether to transcribe a file, use the microphone stream, or run the demo.",
+    )
+    parser.add_argument(
+        "--path",
+        "-p",
+        help="Path to the audio file when using file mode.",
+    )
+    parser.add_argument(
+        "--device",
+        help="Torch device to use (e.g. cpu, cuda, mps). Defaults to auto-detect.",
+    )
+    parser.add_argument(
+        "--chunk-seconds",
+        type=float,
+        default=DEFAULT_MIC_CHUNK_SECONDS,
+        help="Chunk size in seconds when streaming from the microphone.",
+    )
+    parser.add_argument(
+        "--silence-threshold",
+        type=float,
+        default=DEFAULT_SILENCE_THRESHOLD,
+        help="RMS threshold for silence detection during streaming.",
+    )
+    parser.add_argument(
+        "--model-name",
+        default=MODEL_NAME,
+        help="Name of the Hugging Face model to download and run.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        device = pick_device(args.device)
+    except Exception as exc:  # pragma: no cover - user input error
+        print(f"Failed to select device: {exc}", file=sys.stderr)
+        return 2
+
+    recognizer = PhonemeRecognizer(device=device, model_name=args.model_name)
+
+    if args.mode == "file":
+        if not args.path:
+            print("--path is required in file mode", file=sys.stderr)
+            return 2
+        try:
+            transcription = recognizer.transcribe_file(args.path)
+        except Exception as exc:  # pragma: no cover - runtime error
+            print(f"Failed to transcribe file: {exc}", file=sys.stderr)
+            return 1
+        print(transcription)
+        return 0
+
+    if args.mode == "demo":
+        try:
+            transcription = recognizer.run_demo()
+        except Exception as exc:  # pragma: no cover - runtime error
+            print(f"Failed to run demo: {exc}", file=sys.stderr)
+            return 1
+        print(transcription)
+        return 0
+
+    if args.mode == "stream":
+        try:
+            recognizer.stream_microphone(
+                chunk_seconds=args.chunk_seconds,
+                silence_threshold=args.silence_threshold,
+            )
+        except Exception as exc:  # pragma: no cover - runtime error
+            print(f"Streaming failed: {exc}", file=sys.stderr)
+            return 1
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+sounddevice
+soundfile
+datasets
+transformers
+torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ soundfile
 datasets
 transformers
 torch
+torchcodec
+scipy
+phonemizer
+protobuf


### PR DESCRIPTION
## Summary
- add a standalone `phoneme_recognizer.py` script that loads the `facebook/wav2vec2-lv-60-espeak-cv-ft` model for file-based and streaming phoneme recognition
- update the README with setup instructions, usage examples, and optional tuning parameters for the script
- include a `requirements.txt` listing the Python dependencies needed for offline and real-time inference

## Testing
- not run (python dependencies could not be installed in this environment due to proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68dc517e9ea483259ebee329a3dfd0b7