### PR TITLE
Enable remote tokenizer loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ pip install -r requirements.txt
 The script automatically downloads the pretrained model on first use and caches
 it locally using the Hugging Face transformers cache.
 
+> ⚠️ The recognizer now opts into [Hugging Face remote code execution](https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained.remote_code) when loading
+> the model and processor so the custom phoneme tokenizer shipped with the
+> checkpoint is used. Older `transformers` versions without the
+> `trust_remote_code` argument are still supported via a compatibility fallback.
+
 ## Usage
 
 All functionality lives in `phoneme_recognizer.py`. The script exposes three

--- a/phoneme_recognizer.py
+++ b/phoneme_recognizer.py
@@ -64,8 +64,21 @@ class PhonemeRecognizer:
     def __post_init__(self) -> None:
         from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
-        self.processor = Wav2Vec2Processor.from_pretrained(self.model_name)
-        self.model = Wav2Vec2ForCTC.from_pretrained(self.model_name)
+        try:
+            self.processor = Wav2Vec2Processor.from_pretrained(
+                self.model_name, trust_remote_code=True
+            )
+        except TypeError:
+            # Fallback for transformers versions that do not accept trust_remote_code
+            self.processor = Wav2Vec2Processor.from_pretrained(self.model_name)
+
+        try:
+            self.model = Wav2Vec2ForCTC.from_pretrained(
+                self.model_name, trust_remote_code=True
+            )
+        except TypeError:
+            # Fallback for transformers versions that do not accept trust_remote_code
+            self.model = Wav2Vec2ForCTC.from_pretrained(self.model_name)
         self.model.to(self.device)
         self.model.eval()
 


### PR DESCRIPTION
## Summary
- load the wav2vec2 processor and model with trust_remote_code enabled so the custom phoneme tokenizer is available
- retain compatibility with older transformers installs by retrying without the flag when necessary
- document the remote code opt-in in the README so users understand the change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e519f63f64832591bd763f40ec550a